### PR TITLE
Fix version file URL properties

### DIFF
--- a/GameData/NASA_CountDown/NASA_CountDown.version
+++ b/GameData/NASA_CountDown/NASA_CountDown.version
@@ -1,6 +1,6 @@
 {
   "NAME": "NASA_CountDown",
-  "URL": "http://ksp/spacetux.net/avc/NASA_CountDown",
+  "URL": "http://ksp.spacetux.net/avc/NASA_CountDown",
   "DOWNLOAD": "https://github.com/linuxgurugamer/LaunchCountdownEx/releases",
   "GITHUB": {
     "USERNAME": "linuxgurugamer",

--- a/NASA_CountDown.version
+++ b/NASA_CountDown.version
@@ -1,6 +1,6 @@
 {
   "NAME": "NASA_CountDown",
-  "URL": "http://ksp/spacetux.net/avc/NASA_CountDown",
+  "URL": "http://ksp.spacetux.net/avc/NASA_CountDown",
   "DOWNLOAD": "https://github.com/linuxgurugamer/LaunchCountdownEx/releases",
   "GITHUB": {
     "USERNAME": "linuxgurugamer",


### PR DESCRIPTION
See linuxgurugamer/SpaceTuxLibrary#2, these URLs have a `/` where a `.` should be.

Tagging @linuxgurugamer since GitHub notifications are goofy.